### PR TITLE
Fix camera always looking left on MacOS and Linux editor and player

### DIFF
--- a/Assets/Scripts/Office/CameraLook.cs
+++ b/Assets/Scripts/Office/CameraLook.cs
@@ -45,7 +45,9 @@ public class CameraLook : MonoBehaviour {
 
     void Update() {
         switch (Application.platform) {
-            case RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer:
+            case RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer
+                or RuntimePlatform.LinuxEditor or RuntimePlatform.LinuxPlayer
+                or RuntimePlatform.OSXEditor or RuntimePlatform.OSXEditor:
                 mousex = Mouse.current.position.x.ReadValue();
                 mousey = Mouse.current.position.y.ReadValue();
                 break;
@@ -82,49 +84,49 @@ public class CameraLook : MonoBehaviour {
         SwitchTablet();
     }
 
-    void SwitchView(string whereToLook) {
-        if (!tabletScript.isLooking){
-            if (canDoInput) {
-                switch (whereToLook) {
-                    case "left":
-                        if (!anim.IsInTransition(0)) {
-                            switch (anim.GetInteger("Looking")) {
-                                case -1:
-                                    break;
+    void SwitchView(string whereToLook)
+    {
+        if (tabletScript.isLooking) return;
+        if (!canDoInput) return;
+        
+        switch (whereToLook) {
+            case "left":
+                if (!anim.IsInTransition(0)) {
+                    switch (anim.GetInteger("Looking")) {
+                        case -1:
+                            break;
                                 
-                                case 0:
-                                    isLookingAtDoor = true;
-                                    anim.SetInteger("Looking", -1);
-                                    break;
+                        case 0:
+                            isLookingAtDoor = true;
+                            anim.SetInteger("Looking", -1);
+                            break;
                                 
-                                case 1:
-                                    isLookingAtDoor = false;
-                                    anim.SetInteger("Looking", 0);
-                                    break;
-                            }
-                        }
-                        break;
-                
-                    case "right":
-                        if (!anim.IsInTransition(0)) {
-                                switch (anim.GetInteger("Looking")) {
-                                    case -1:
-                                        isLookingAtDoor = false;
-                                        anim.SetInteger("Looking", 0);
-                                        break;
-                                    
-                                    case 0:
-                                        isLookingAtDoor = true;
-                                        anim.SetInteger("Looking", 1);
-                                        break;
-                                    
-                                    case 1:
-                                        break;
-                                }
-                        }
-                        break;
+                        case 1:
+                            isLookingAtDoor = false;
+                            anim.SetInteger("Looking", 0);
+                            break;
+                    }
                 }
-            }
+                break;
+                
+            case "right":
+                if (!anim.IsInTransition(0)) {
+                    switch (anim.GetInteger("Looking")) {
+                        case -1:
+                            isLookingAtDoor = false;
+                            anim.SetInteger("Looking", 0);
+                            break;
+                                    
+                        case 0:
+                            isLookingAtDoor = true;
+                            anim.SetInteger("Looking", 1);
+                            break;
+                                    
+                        case 1:
+                            break;
+                    }
+                }
+                break;
         }
     }
     

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -14,6 +14,7 @@
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
     "com.unity.toolchain.linux-x86_64": "2.0.3",
+    "com.unity.toolchain.macos-arm64-linux-x86_64": "2.0.3",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.7.8",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -147,18 +147,18 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.sysroot": {
-      "version": "2.0.4",
+      "version": "2.0.10",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.sysroot.linux-x86_64": {
-      "version": "2.0.3",
+      "version": "2.0.9",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.sysroot": "2.0.4"
+        "com.unity.sysroot": "2.0.10"
       },
       "url": "https://packages.unity.com"
     },
@@ -211,6 +211,16 @@
       "dependencies": {
         "com.unity.sysroot": "2.0.4",
         "com.unity.sysroot.linux-x86_64": "2.0.3"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.macos-arm64-linux-x86_64": {
+      "version": "2.0.3",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10",
+        "com.unity.sysroot.linux-x86_64": "2.0.9"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
In Scripts/Office/CameraLook.cs in Update at line 48 (`case RuntimePlatform.WindowsEditor or RuntimePlatform.WindowsPlayer:`) the script didn't check for Mac and Linux platforms.
Fixes #13.